### PR TITLE
feat: add device metadata headers and UI tracking

### DIFF
--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -4,21 +4,27 @@ import { catchError, Observable, switchMap, throwError }            from 'rxjs';
 
 import { AuthService } from '@core/auth/auth.service';
 import { AuthUtils }   from '@core/auth/auth.utils';
+import { DeviceService } from '@core/device/device.service';
+import { environment } from 'environments/environment';
 
 export const authInterceptor = (
     req: HttpRequest<unknown>,
     next: HttpHandlerFn
 ): Observable<HttpEvent<unknown>> => {
-    const authService = inject(AuthService);
+    const authService  = inject(AuthService);
+    const deviceService = inject(DeviceService);
 
-    let newReq = req.clone();
+    let headers = req.headers
+        .set('device-id', deviceService.getDeviceId())
+        .set('user-agent', navigator.userAgent)
+        .set('app-version', environment.appVersion)
+        .set('environment', environment.production ? 'production' : 'development');
 
-    // Agrega el Bearer token si no está expirado
     if (authService.accessToken && !AuthUtils.isTokenExpired(authService.accessToken) && !req.headers.get('Authorization')) {
-        newReq = req.clone({
-            headers: req.headers.set('Authorization', 'Bearer ' + authService.accessToken),
-        });
+        headers = headers.set('Authorization', 'Bearer ' + authService.accessToken);
     }
+
+    let newReq = req.clone({ headers });
 
     // Manejo de errores
     return next(newReq).pipe(
@@ -35,9 +41,9 @@ export const authInterceptor = (
                 return authService.signInUsingToken().pipe(
                     catchError(() => authService.signOut()),
                     switchMap(() => {
-                        // Reintentar el request original con el nuevo token
+                        // Reintentar el request original con el nuevo token y headers de contexto
                         newReq = req.clone({
-                            headers: req.headers.set('Authorization', 'Bearer ' + authService.accessToken),
+                            headers: headers.set('Authorization', 'Bearer ' + authService.accessToken),
                         });
                         return next(newReq);
                     })

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -14,10 +14,15 @@ export const authInterceptor = (
     const authService  = inject(AuthService);
     const deviceService = inject(DeviceService);
 
+    const requestId = crypto.randomUUID();
+
     let headers = req.headers
-        .set('device-id', deviceService.getDeviceId())
+        .set('x-device-id', deviceService.getDeviceId())
+        .set('x-session-id', deviceService.getSessionId())
         .set('user-agent', navigator.userAgent)
-        .set('app-version', environment.appVersion)
+        .set('x-app-version', environment.appVersion)
+        .set('x-request-id', requestId)
+        .set('x-trace-id', requestId)
         .set('environment', environment.production ? 'production' : 'development');
 
     if (authService.accessToken && !AuthUtils.isTokenExpired(authService.accessToken) && !req.headers.get('Authorization')) {

--- a/src/app/core/device/device.service.ts
+++ b/src/app/core/device/device.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+const STORAGE_KEY = 'deviceId';
+
+@Injectable({ providedIn: 'root' })
+export class DeviceService {
+    getDeviceId(): string {
+        let id = localStorage.getItem(STORAGE_KEY);
+        if (!id) {
+            id = crypto.randomUUID();
+            localStorage.setItem(STORAGE_KEY, id);
+        }
+        return id;
+    }
+}

--- a/src/app/core/device/device.service.ts
+++ b/src/app/core/device/device.service.ts
@@ -1,14 +1,24 @@
 import { Injectable } from '@angular/core';
 
-const STORAGE_KEY = 'deviceId';
+const DEVICE_KEY = 'deviceId';
+const SESSION_KEY = 'sessionId';
 
 @Injectable({ providedIn: 'root' })
 export class DeviceService {
     getDeviceId(): string {
-        let id = localStorage.getItem(STORAGE_KEY);
+        let id = localStorage.getItem(DEVICE_KEY);
         if (!id) {
             id = crypto.randomUUID();
-            localStorage.setItem(STORAGE_KEY, id);
+            localStorage.setItem(DEVICE_KEY, id);
+        }
+        return id;
+    }
+
+    getSessionId(): string {
+        let id = sessionStorage.getItem(SESSION_KEY);
+        if (!id) {
+            id = crypto.randomUUID();
+            sessionStorage.setItem(SESSION_KEY, id);
         }
         return id;
     }

--- a/src/app/core/tracking/tracking.service.ts
+++ b/src/app/core/tracking/tracking.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from 'environments/environment';
+import { DeviceService } from '@core/device/device.service';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+interface TrackedEvent {
+    name: string;
+    data?: any;
+    timestamp: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TrackingService {
+    private events: TrackedEvent[] = [];
+    private enabled = true;
+
+    constructor(private http: HttpClient, private deviceService: DeviceService) {}
+
+    enable(enabled: boolean): void {
+        this.enabled = enabled;
+    }
+
+    track(name: string, data?: any): void {
+        if (!this.enabled) {
+            return;
+        }
+        this.events.push({ name, data, timestamp: Date.now() });
+    }
+
+    flush(): Observable<unknown> {
+        if (!this.enabled || this.events.length === 0) {
+            return of(null);
+        }
+
+        const payload = {
+            deviceId: this.deviceService.getDeviceId(),
+            events: this.events,
+        };
+
+        return this.http.post(`${environment.BACKEND_URL}ui-events`, payload).pipe(
+            tap(() => (this.events = []))
+        );
+    }
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,11 +1,14 @@
+import packageJson from '../../package.json';
+
 export const environment = {
   production : false,
+  appVersion : packageJson.version,
   BACKEND_URL: 'http://localhost:3000/',
   ENCRYPTION_KEY: '2dc38ecf-0aef-443c-8585-ea876df46493',
-    GMAPS_API_KEY: 'AIzaSyDuuXk4YZ8E5mPXUsrqmGHbSHel4BniHCs',
-    // API keys for utility widgets
-    fuelApiKey     : 'YOUR_FUEL_API_KEY', // Replace with actual fuel prices API key
-    fuelApiEmail   : 'david.misa97@gmail.com', // Replace with actual fuel API email
-    fuelApiPassword: 'DavidVillegas97', // Replace with actual fuel API password
-    newsApiKey     : 'YOUR_NEWS_API_KEY' // Replace with actual news API key
+  GMAPS_API_KEY  : 'AIzaSyDuuXk4YZ8E5mPXUsrqmGHbSHel4BniHCs',
+  // API keys for utility widgets
+  fuelApiKey     : 'YOUR_FUEL_API_KEY', // Replace with actual fuel prices API key
+  fuelApiEmail   : 'david.misa97@gmail.com', // Replace with actual fuel API email
+  fuelApiPassword: 'DavidVillegas97', // Replace with actual fuel API password
+  newsApiKey     : 'YOUR_NEWS_API_KEY' // Replace with actual news API key
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,10 +1,13 @@
+import packageJson from '../../package.json';
+
 export const environment = {
     production    : true,
+    appVersion    : packageJson.version,
     BACKEND_URL   : 'https://wwt-auth-production.up.railway.app/',
     ENCRYPTION_KEY: '2dc38ecf-0aef-443c-8585-ea876df46493',
     GMAPS_API_KEY : 'AIzaSyDuuXk4YZ8E5mPXUsrqmGHbSHel4BniHCs',
-    OSRM_URL: 'https://osrm-car-chile-production.up.railway.app',
-    apiUrl: 'https://wwt-auth-production.up.railway.app',
+    OSRM_URL      : 'https://osrm-car-chile-production.up.railway.app',
+    apiUrl        : 'https://wwt-auth-production.up.railway.app',
     // API keys for utility widgets
     fuelApiKey     : 'YOUR_FUEL_API_KEY', // Replace with actual fuel prices API key
     fuelApiEmail   : 'david.misa97@gmail.com', // Replace with actual fuel API email


### PR DESCRIPTION
## Summary
- generate persistent deviceId and include device, agent, version, and environment headers on requests
- track key UI events locally with optional flush to backend
- expose app version from package.json in environments

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Module not found: Can't resolve 'zone.js/testing'; TS errors in checklist.service.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689183df4edc8324a21315fea9ed077b